### PR TITLE
fix: correct repository link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 A minimal and flexible template to quickly deploy a simple server using Docker Compose.
 
-**🎊 Based on [mauroalderete/base-template](https://github.com/mauroalderete/server-template) 🎊**.
+**🎊 Based on [mauroalderete/server-template](https://github.com/mauroalderete/server-template) 🎊**.
 
 Use this template as a starting point for creating personalized server configurations across your network with ease. Includes essential components to set up and manage a lightweight server for various machines, such as Raspberry Pi, personal computers, or other servers in your network.
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change corrects the link to the base template repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48): Updated the link to the base template repository from `mauroalderete/base-template` to `mauroalderete/server-template`.