### PR TITLE
4 fix some bugs in documentation and default config in loadbalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,27 @@ For that the discovery service works and it be able to find the services running
 For default, the network is called `myserver`. You can change this name in the `docker-compose.yaml` file.
 
 ```yaml
+services:
+  <service_name>:
+    networks:
+      - myserver
+
+...
+
 networks:
-  default:
-    name: myserver
+  myserver:
     external: true
 ```
 
 If you change the network name, you need to change the network name in the `docker-compose.yaml` file of the services that you want to deploy in the same network.
+
+If you change the network name, you need to change the network name in the docker-compose.yaml file of the services that you want to deploy in the same network. Additionaly, you need edit the ./traefik/traefik.yml file to change the network for Docker provider.
+
+```yaml
+providers:
+  docker:
+    network: myserver
+```
 
 ### mDNS
 
@@ -203,9 +217,15 @@ A fixed service is a service that you want to run in your server and always be a
 First, you need run the service in the same network that the discovery service is running. You can use the `networks` section in the `docker-compose.yaml` file to add the service to the network.
 
 ```yaml
+services:
+  <service_name>:
+    networks:
+      - myserver
+
+...
+
 networks:
-  default:
-    name: myserver
+  myserver:
     external: true
 ```
 
@@ -256,9 +276,15 @@ A discovery service is a service that you want to run in your server and be disc
 First, you need run the service in the same network that the discovery service is running. You can use the `networks` section in the `docker-compose.yaml` file to add the service to the network.
 
 ```yaml
+services:
+  <service_name>:
+    networks:
+      - myserver
+
+...
+
 networks:
-  default:
-    name: myserver
+  myserver:
     external: true
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - "traefik.http.routers.traefik.tls=true"
       - "traefik.http.routers.traefik-insecure.rule=Host(`traefik.myserver.local`)"
       - "traefik.http.routers.traefik-insecure.entrypoints=web"
-      - "traefik.http.services.traefik.loadbalancer.myserver.port=8080"
+      - "traefik.http.services.traefik.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.testheader.headers.accesscontrolallowmethods=GET,OPTIONS,PUT"
       - "traefik.http.middlewares.testheader.headers.accesscontrolallowheaders=*"
       - "traefik.http.middlewares.testheader.headers.accesscontrolalloworiginlist=https://myserver.local,http://myserver.local"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro # Mount the Docker socket so Traefik can listen to events
       - ./traefik:/etc/traefik # Mount the configuration folder
+    networks:
+      - myserver
 
   dockerproxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:latest
@@ -36,6 +38,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: always
+    networks:
+      - myserver
 
   gethomepage:
     image: ghcr.io/gethomepage/homepage:latest
@@ -56,8 +60,9 @@ services:
       - ./gethomepage/images:/app/public/images
       - ./gethomepage/icons:/app/public/icons
     restart: always
+    networks:
+      - myserver
 
 networks:
-  default:
-    name: myserver
+  myserver:
     external: true


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `docker-compose.yaml` files to improve network configuration and correct a service port reference. The most important changes include adding the `networks` section to various services in the `docker-compose.yaml` file and updating the network name references.

Updates to network configuration:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95-R116): Added instructions to update the `docker-compose.yaml` and `./traefik/traefik.yml` files when changing the network name.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R25-R26): Added the `networks` section to the `traefik`, `dockerproxy`, and `gethomepage` services to ensure they are connected to the `myserver` network. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R25-R26) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R41-R42) [[3]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R63-R67)

Corrections to service configuration:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L13-R13): Corrected the `traefik` service port reference from `loadbalancer.myserver.port` to `loadbalancer.server.port`.